### PR TITLE
Add cooldowns for commands that use MQTT

### DIFF
--- a/bot/baldaio.py
+++ b/bot/baldaio.py
@@ -62,34 +62,3 @@ class AIO:
         except RequestError as e:
             print(e)
             return False
-
-
-# def push_attn(feed="twitch-attn-indi"):
-#     if AddOhmsBot.AIO_CONNECTION_STATE is False:
-#         print("Not even trying, we aren't connected")
-#         return False
-#     try:
-#         AddOhmsBot.Adafruit_IO.send_data(feed, 1)
-#         return True
-#     except RequestError as e:
-#         print(e)
-#         return False
-
-
-# def increment_feed(feed="treat-counter-text"):
-#     if AddOhmsBot.AIO_CONNECTION_STATE is False:
-#         print("Not publishing, we aren't connected")
-#         return False
-
-#     feed_data = AddOhmsBot.Adafruit_IO.data(feed)  # returns an array of values
-#     feed_value = int(feed_data[0].value)  # this feed only has 1
-
-#     feed_value += 1
-
-#     print("sending count: ", feed_value)
-#     try:
-#         AddOhmsBot.Adafruit_IO.send_data("treat-counter-text", feed_value)
-#         return True
-#     except RequestError as e:
-#         print(e)
-#         return False

--- a/bot/commands/treatme.py
+++ b/bot/commands/treatme.py
@@ -1,12 +1,49 @@
 from main import AddOhmsBot
 from twitchbot import Command
+from twitchbot import SubCommand
+from twitchbot.database.session import session
+
+from mods.database_models import Settings
+
+# Key that is sent to Adafruit.IO
+aio_key = "dispense-treat-toggle"
+
+# Set a default cooldown
+q = session.query(Settings.value).filter(Settings.key == "treatbot_mqtt_cooldown").one_or_none()
+if q is None:
+    # Value wasn't in the database, lets insert it.
+    insert = Settings(key="treatbot_mqtt_cooldown", value=300)
+    session.add(insert)
+    AddOhmsBot.AIO.mqtt_cooldown[aio_key] = 300
+else:
+    AddOhmsBot.AIO.mqtt_cooldown[aio_key] = int(q[0])
 
 
 @Command("treatme")
 async def push_treat(msg, *args):
-    if AddOhmsBot().AIO.send("dispense-treat-toggle"):
+    if AddOhmsBot().AIO.send(aio_key):
         await msg.reply(f"{AddOhmsBot.msg_prefix}Teleporting a treat")
     else:
         await msg.reply(f"{AddOhmsBot.msg_prefix}I couldn't do that at the moment. Sorry ☹️")
 
-    # baldaio.push_attn('dispense-treat-toggle')
+
+@SubCommand(push_treat, "cooldown", permission="admin")
+async def treatme_cooldown(msg, *args):
+    cooldown = AddOhmsBot.AIO.mqtt_cooldown
+
+    try:
+        new_cooldown = int(args[0])
+        cooldown[aio_key] = new_cooldown
+        session.query(Settings).filter(Settings.key == "treatbot_mqtt_cooldown").update({"value": new_cooldown})
+        await msg.reply(f"Treatme cooldown changed to {new_cooldown}")
+
+    except IndexError:
+        await msg.reply(f"Current cooldown is {cooldown[aio_key]} seconds.")
+        return
+
+    except ValueError:
+        await msg.reply("Invalid value.")
+
+    except Exception as e:
+        print(type(e), e)
+        return

--- a/bot/commands/treatme.py
+++ b/bot/commands/treatme.py
@@ -1,22 +1,9 @@
 from main import AddOhmsBot
 from twitchbot import Command
 from twitchbot import SubCommand
-from twitchbot.database.session import session
-
-from mods.database_models import Settings
 
 # Key that is sent to Adafruit.IO
 aio_key = "dispense-treat-toggle"
-
-# Set a default cooldown
-q = session.query(Settings.value).filter(Settings.key == "treatbot_mqtt_cooldown").one_or_none()
-if q is None:
-    # Value wasn't in the database, lets insert it.
-    insert = Settings(key="treatbot_mqtt_cooldown", value=300)
-    session.add(insert)
-    AddOhmsBot.AIO.mqtt_cooldown[aio_key] = 300
-else:
-    AddOhmsBot.AIO.mqtt_cooldown[aio_key] = int(q[0])
 
 
 @Command("treatme")
@@ -29,16 +16,16 @@ async def push_treat(msg, *args):
 
 @SubCommand(push_treat, "cooldown", permission="admin")
 async def treatme_cooldown(msg, *args):
-    cooldown = AddOhmsBot.AIO.mqtt_cooldown
-
     try:
         new_cooldown = int(args[0])
-        cooldown[aio_key] = new_cooldown
-        session.query(Settings).filter(Settings.key == "treatbot_mqtt_cooldown").update({"value": new_cooldown})
+
+        # Update the database
+        AddOhmsBot.AIO.set_cooldown(aio_key, new_cooldown)
+
         await msg.reply(f"Treatme cooldown changed to {new_cooldown}")
 
     except IndexError:
-        await msg.reply(f"Current cooldown is {cooldown[aio_key]} seconds.")
+        await msg.reply(f"Current cooldown is {AddOhmsBot.AIO.get_cooldown(aio_key)} seconds.")
         return
 
     except ValueError:

--- a/bot/mods/channel_points.py
+++ b/bot/mods/channel_points.py
@@ -4,6 +4,8 @@ from twitchbot import channels
 from twitchbot import Message
 from twitchbot import Mod
 from twitchbot import PubSubData
+from twitchbot.command import ModCommand
+from twitchbot.command import SubCommand
 
 
 class ChannelPoints(Mod):
@@ -48,7 +50,6 @@ class ChannelPoints(Mod):
         if AddOhmsBot.AIO.send("dispense-treat-toggle"):
             await channels[channel].send_message(f"{AddOhmsBot.msg_prefix}Teleporting a treat")
         else:
-            # chan = cfg.channels[0]
             await channels[channel].send_message(f"{AddOhmsBot.msg_prefix}I couldn't do that at the moment. Sorry ☹️")
 
         print("Dispensing a treat!")
@@ -57,7 +58,6 @@ class ChannelPoints(Mod):
         print("Hey!!!")
         if AddOhmsBot.ATTN_ENABLE:
             if not AddOhmsBot.AIO.send("twitch-attn-indi"):
-                # chan = cfg.channels[0]
                 await channels[channel].send_message(f"{AddOhmsBot.msg_prefix}Something went wrong getting my attention. ☹️")
 
         else:
@@ -65,3 +65,57 @@ class ChannelPoints(Mod):
 
     async def highlighted_message(self):
         print("Highlighted message.")
+
+    @ModCommand(name, "channelpoint_cooldown", permission="admin")
+    async def channelpoint_cooldown(self, msg, *args):
+        # Nothing really to do here
+        pass
+
+    @SubCommand(channelpoint_cooldown, "attention", permission="admin")
+    async def attention_cooldown(self, msg, *args):
+        aio_key = "twitch-attn-indi"
+
+        try:
+            new_cooldown = int(args[0])
+            # Update the database
+            AddOhmsBot.AIO.set_cooldown(aio_key, new_cooldown)
+
+            await msg.reply(f"Attention cooldown changed to {new_cooldown}")
+
+        except IndexError:
+            await msg.reply(f"Current cooldown is {AddOhmsBot.AIO.get_cooldown(aio_key)} seconds.")
+            return
+
+        except ValueError:
+            await msg.reply("Invalid value.")
+
+        except Exception as e:
+            print(type(e), e)
+            return
+
+    @SubCommand(channelpoint_cooldown, "treat", permission="admin")
+    async def treat_cooldown(self, msg, *args):
+        """
+        This entire function is a duplicate from `commands/treatme.py`
+        and is only here for completeness, or if the command is removed.
+        """
+        aio_key = "dispense-treat-toggle"
+
+        try:
+            new_cooldown = int(args[0])
+
+            # Update the database
+            AddOhmsBot.AIO.set_cooldown(aio_key, new_cooldown)
+
+            await msg.reply(f"Treatme cooldown changed to {new_cooldown}")
+
+        except IndexError:
+            await msg.reply(f"Current cooldown is {AddOhmsBot.AIO.get_cooldown(aio_key)} seconds.")
+            return
+
+        except ValueError:
+            await msg.reply("Invalid value.")
+
+        except Exception as e:
+            print(type(e), e)
+            return


### PR DESCRIPTION
@baldengineer Requires adding `channelpoint_cooldown` to command whitelist
#20